### PR TITLE
Add missing babel-runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "watch": "node ./bin/runner --watch"
   },
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "debug": "3.2.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Hi, thanks for the cool library! However, when I try to add it to my project, I get the following error:

```
Error: Cannot find module 'babel-runtime/helpers/classCallCheck'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:594:15)
    at Function.Module._load (internal/modules/cjs/loader.js:520:25)
    at Module.require (internal/modules/cjs/loader.js:650:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/Users/delany/Documents/repos/sync-test/node_modules/@ircam/sync/server/index.js:7:24)
```

It seems this is because the library is using Babel runtime helpers but they are not included in `dependencies`. According to the Babel docs, the runtime transform should be in `devDependencies` and the actual runtime library should be included in `dependencies`:

https://babeljs.io/docs/en/babel-plugin-transform-runtime

Here is discussion of the same issue on a different project:

https://github.com/bookshelf/bookshelf/issues/1188

I tested this fix locally via `npm link` and it seems to work 👍For anyone looking for a temporary workaround until this is merged - you can also navigate to your project's `node_modules/@ircam/sync` folder and run `npm install` to install the missing dependency.